### PR TITLE
Update JBProjectHandles.sol

### DIFF
--- a/contracts/JBProjectHandles.sol
+++ b/contracts/JBProjectHandles.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.16;
+pragma solidity 0.8.6;
 
 import '@ensdomains/ens-contracts/contracts/resolvers/profiles/ITextResolver.sol';
 import '@jbx-protocol/contracts-v2/contracts/abstract/JBOperatable.sol';

--- a/contracts/JBProjectHandles.sol
+++ b/contracts/JBProjectHandles.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.16;
 
 import '@ensdomains/ens-contracts/contracts/resolvers/profiles/ITextResolver.sol';
 import '@jbx-protocol/contracts-v2/contracts/abstract/JBOperatable.sol';

--- a/contracts/interfaces/IJBProjectHandles.sol
+++ b/contracts/interfaces/IJBProjectHandles.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity ^0.8.16;
 
 import '@ensdomains/ens-contracts/contracts/resolvers/profiles/ITextResolver.sol';
 import '@jbx-protocol/contracts-v2/contracts/interfaces/IJBProjects.sol';


### PR DESCRIPTION
Adding a `^` to the pragma so it plays nice with other `0.8.x` imports, such as my tokenUriResolver contract.

I also updated to `^0.8.16` as that's what I see in the rest of v3.

UPDATE: This is producing a compilation error so best not to merge as-is.