### PR TITLE
Fix remappings.txt

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,3 @@
 @contracts/=contracts/
-@ensdomains/=node_modules/@ensdomains/
-@jbx-protocol/=node_modules/@jbx-protocol/
-@openzeppelin/=node_modules/@openzeppelin/
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/


### PR DESCRIPTION
Fix remappings.txt which was including node_modules remapping.
These are not needed (Forge does it by itself) + create bugs when importing this repo in other forge repo's