### PR TITLE
Change npm pkg name @jbx-protocol/juice-project-handles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jbx-protocol/project-handles",
+  "name": "@jbx-protocol/juice-project-handles",
   "bugs": {
     "url": "https://github.com/jbx-protocol/juice-project-handles/issues"
   },


### PR DESCRIPTION
Change the name of the Project Handles package from '@jbx-protocol/project-handles' to  '@jbx-protocol/juice-project-handles' to be congruent with the github repo name.